### PR TITLE
Took out unnecessary connectivity logic in footer

### DIFF
--- a/app/partials/footer.html
+++ b/app/partials/footer.html
@@ -3,17 +3,7 @@
     {{ 'CONNECTION_OFFLINE' | i18n }}
   </div>
   <div ng-show="model.connectivity.internet != false">
-    <div id="still-connecting" ng-show="inGetMode && model.connectivity.nproxies == -1">
-      {{ 'CONNECTING' | i18n }}<br>
-    </div>
-    <div id="noproxies" ng-show="inGetMode && model.connectivity.nproxies == 0">
-      {{ 'NO_PROXIES' | i18n }}<br>
-      <!--
-      {{ 'WAIT_FOR_FRIEND_OR' | i18n }}
-      <a class="always-underlined warning-colored" ng-click="interaction(INTERACTION.sponsor)">{{ 'SPONSOR_NOW' | i18n }}</a>
-      -->
-    </div>
-    <div id="stats" ng-show="!inGetMode || model.connectivity.nproxies > 0">
+    <div id="stats">
       <div ng-show="statsLoaded">
         {{ 'NUSERS_ONLINE' | i18n:(model.globalStats.gauges.userOnline || 0) }} ·
         {{ 'NUSERS_EVER' | i18n:(model.globalStats.gauges.userOnlineEver + model.globalStats.counters.userOnlineEverOld) }} ·


### PR DESCRIPTION
For #2196.  The nproxies figure isn't being updated anymore now that we manage all proxies in flashlight, and as long as we're connected to the internet we consider ourselves to be ready to proxy.